### PR TITLE
Code restructuring: new project and some new type names, streamlined tensor handling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "NanoWiresJulia"
+name = "StrainedBandstructures"
 uuid = "3e3237d9-63df-4510-8634-5aa762e77746"
 authors = ["Patricio Farrell", "Yiannis Hadjimichael", "Christian Merdon"]
 version = "0.1.0"
@@ -32,10 +32,10 @@ Triangulate = "f7e6ffb2-c36d-4f8f-a77e-16e897189344"
 XLSX = "fdbf4ff8-1666-58a4-91e7-1b58723a45e0"
 
 [compat]
-ExtendableFEM = "^0.5.0"
-ExtendableFEMBase = "^0.6"
-ExtendableGrids = "^1.5.0"
 DocStringExtensions = "0.8,0.9"
+ExtendableFEM = "^0.7"
+ExtendableFEMBase = "^0.7"
+ExtendableGrids = "^1.9.2"
 GridVisualize = "1.1.7"
 Pardiso = "0.5.3"
 SimplexGridFactory = "^2.0.1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,7 +7,7 @@ makedocs(
 		modules = [StrainedBandstructures],
 		sitename = "StrainedBandStructures.jl",
 		authors = "Patricio Farrell, Yiannis Hadjimichael, Christian Merdon",
-		repo = "github.com/hadjimy/StrainedBandstructures",
+		format = Documenter.HTML(; repolink = "https://github.com/hadjimy/StrainedBandstructures", mathengine = MathJax3()),
 		clean = false,
 		source  = "src",
 		build   = "build",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,10 +1,10 @@
 using Documenter
-using NanoWiresJulia
+using StrainedBandstructures
 
 push!(LOAD_PATH,"../src/")
 
 makedocs(
-		modules = [NanoWiresJulia],
+		modules = [StrainedBandstructures],
 		sitename = "StrainedBandStructures.jl",
 		authors = "Patricio Farrell, Yiannis Hadjimichael, Christian Merdon",
 		repo = "github.com/hadjimy/StrainedBandstructures",

--- a/docs/src/materialdata.md
+++ b/docs/src/materialdata.md
@@ -1,16 +1,17 @@
 # Material Data
 
-## Material data sets
+## MaterialParameters
+
+This structure stores all implemented parameters for a material.
 
 ```@docs
-MaterialDataset
-MaterialData
+MaterialParameters
 ```
 
 ## Material structure types
 
 ```@autodocs
-Modules = [NanoWiresJulia]
+Modules = [StrainedBandstructures]
 Pages = ["materialstructuretype.jl"]
 Order   = [:type, :function]
 ```
@@ -24,3 +25,16 @@ AlInAs
 AlGaAs
 InGaAs
 ```
+
+## HeteroStructureData
+
+A hetero-structure consists of several materials related to the region numbers of the
+grid. The HeteroStructureData is a structure that stores the MaterialParameters
+of all materials/regions and the derived elasticity and piezo-eletricity tensors.
+
+```@autodocs
+Modules = [StrainedBandstructures]
+Pages = ["heterostructures.jl"]
+Order   = [:type, :function]
+```
+

--- a/docs/src/tensors.md
+++ b/docs/src/tensors.md
@@ -1,22 +1,22 @@
 # Tensors
 
-## Elasticity tensors
+## Custom tensors 
 
-These are the avaiable elasticity tensor types...
+Custom tensors are based on a matrix representation that maps one vector to another, e.g. a Voigt representation of the strain to the Voigt representation of the stress. The matrix representation can be defined as a DenseMatrix or a SparseMatrix.
 
 ```@docs
-ElasticityTensorType
-IsotropicElasticityTensor
-CustomMatrixElasticityTensor
+AbstractTensor
+SparseMatrixTensor
+DenseMatrixTensor
 ```
 
+Currently DenseMatrixTensors are used to represent the elasticity and piezoeletricity tensors.
 
-## Piezo-electricity tensors
+## Isotropic Elasticity tensors
 
-
-These are the avaiable piezo-electricity tensor types...
+For linear elasticity, a special constructor for the isotropic elasticity tensor is available:
 
 ```@docs
-PiezoElectricityTensorType
-CustomMatrixPiezoElectricityTensor
+IsotropicElasticityTensor
+IsotropicElasticityTensor(MD::MaterialParameters{T, MT, MST}) where {T,MT,MST}
 ```

--- a/notebooks/plotting.jl
+++ b/notebooks/plotting.jl
@@ -12,7 +12,7 @@ begin
     Pkg.activate(joinpath(@__DIR__,".."))
     using Revise
     using PlutoUI
-    using NanoWiresJulia
+    using StrainedBandstructures
     using ExtendableGrids
     using GridVisualize
     using PlutoVista
@@ -107,7 +107,7 @@ let
 end
 
 # ╔═╡ 65de36ff-5043-465f-beef-b2e2e7819ba2
-md" ## Functions from NanoWiresJulia package"
+md" ## Functions from StrainedBandstructures package"
 
 # ╔═╡ 0658ec32-ba72-42ee-b8e5-6b2cd62d88b9
 function asign_nodes(p,builder,shape,d1,d2,δ)

--- a/scripts/bimetal_thermal_vs_lattice.jl
+++ b/scripts/bimetal_thermal_vs_lattice.jl
@@ -1,6 +1,6 @@
 module bimetal
 
-using NanoWiresJulia
+using StrainedBandstructures
 using GradientRobustMultiPhysics
 using ExtendableGrids
 using SimplexGridFactory

--- a/scripts/nanowire.jl
+++ b/scripts/nanowire.jl
@@ -1,6 +1,6 @@
 module nanowire
 
-using NanoWiresJulia
+using StrainedBandstructures
 using ExtendableFEM
 using ExtendableFEMBase
 using ExtendableGrids
@@ -20,7 +20,7 @@ using Pardiso
 ## postprocess data with postprocess(; Plotter = PyPlot) --> images go to plots directory
 
 # configure Watson
-@quickactivate "NanoWiresJulia" # <- project name
+@quickactivate "StrainedBandstructures" # <- project name
 # set parameters that should be included in filename
 watson_accesses = ["geometry", "nrefs", "femorder", "mstruct", "stressor_x", "full_nonlin", "interface_refinement", "cross_section", "rotate"]
 watson_allowedtypes = (Real, String, Symbol, Array, DataType)
@@ -87,7 +87,7 @@ function get_scenario(scenario, shell_x, stressor_x, materialstructuretype)
     else
         @error "scenario not defined"
     end
-    MD = set_data(materials, materialstructuretype)
+    MD = HeteroStructureData(materials, materialstructuretype)
     return MD
 end
 
@@ -228,7 +228,7 @@ function main(d = nothing; verbosity = 0, Plotter = nothing, force::Bool = false
     if (use_lowlevel_solver)
         @assert polarisation == false
         BoundaryOperator = HomogeneousBoundaryData(1; regions = regions_bc)
-        DisplacementOperator = get_displacement_operator_new(MD.TensorC, strainm, estrainm, eps0, a; dim = 3, displacement = u, emb = parameters, regions = 1:nregions, bonus_quadorder = bonus_quadorder)
+        DisplacementOperator = get_displacement_operator(MD.TensorC, strainm, estrainm, eps0, a; dim = 3, displacement = u, emb = parameters, regions = 1:nregions, bonus_quadorder = bonus_quadorder)
         PolarisationOperator = nothing
         Solution, last_residual = solve_lowlevel(xgrid,
                                 BoundaryOperator,
@@ -303,7 +303,7 @@ function main(d = nothing; verbosity = 0, Plotter = nothing, force::Bool = false
 end
 
 
-function get_lattice_misfit_nanowire(lcavg_case, MD::MaterialData, geometry, full_nonlin)
+function get_lattice_misfit_nanowire(lcavg_case, MD::HeteroStructureData, geometry, full_nonlin)
 
     nregions = length(MD.data)
     lc_avg::Array{Float64,1} = zeros(Float64,3)

--- a/src/StrainedBandstructures.jl
+++ b/src/StrainedBandstructures.jl
@@ -1,4 +1,4 @@
-module NanoWiresJulia
+module StrainedBandstructures
 
 using ExtendableFEM
 using ExtendableFEMBase
@@ -43,18 +43,21 @@ include("materialstructuretype.jl")
 export MaterialStructureType
 export ZincBlende2D, ZincBlende001, ZincBlende111_C14, ZincBlende111_C15, ZincBlende111_C14_C15, Wurtzite0001
 
-include("tensors.jl")
-export ElasticityTensorType, PiezoElectricityTensorType
-export IsotropicElasticityTensor
-export CustomMatrixElasticityTensor, CustomMatrixPiezoElectricityTensor
-export apply_elasticity_tensor!, apply_piezoelectricity_tensor!
-
 include("materials.jl")
 export MaterialType
 export TestMaterial, GaAs, AlInAs, AlGaAs, InGaAs
-export MaterialDataset
+export MaterialParameters
 export get_materialtype
-export MaterialData
+
+include("tensors.jl")
+export AbstractTensor
+export DenseMatrixTensor, SparseMatrixTensor
+export IsotropicElasticityTensor
+export apply_tensor!
+
+
+include("heterostructures.jl")
+export HeteroStructureData
 export set_data
 
 include("strains.jl")
@@ -67,7 +70,7 @@ export eval_strain!, eval_elastic_strain!
 
 include("pdeoperators.jl")
 export PDEDisplacementOperator, PDEPolarisationOperator
-export get_displacement_operator, get_displacement_operator_new
+export get_displacement_operator, get_displacement_operator
 export get_polarisation_from_strain_operator
 export get_polarisation_laplacian_operator
 export get_polarisation_operator # wip

--- a/src/heterostructures.jl
+++ b/src/heterostructures.jl
@@ -1,0 +1,162 @@
+
+"""
+    $(TYPEDEF)
+
+structure that collects material data sets, elasticity tensors and piezoelectric tensors for all materials
+"""
+struct HeteroStructureData{T, MST <: MaterialStructureType}
+    data::Array{MaterialParameters,1}
+    TensorC::Array{AbstractTensor{T},1}         # elastitity tensor C
+    TensorE::Array{AbstractTensor{T},1}   # piezo-electricity tensor E
+end
+
+"""
+````
+function HeteroStructureData(materials::Array{MaterialParameters,1}, MST::Type{<:MaterialStructureType})
+````
+
+construct a HeteroStructureData from the given array of MaterialParameters and
+generates the elasticity and piezo-eletricity tensors for the given MaterialStructureTypes
+"""
+function HeteroStructureData(materials::Array{DataType,1}, MST::Type{<:MaterialStructureType}, TensorMatrixType = DenseMatrixTensor)
+
+    data = Array{MaterialParameters,1}(undef, length(materials))
+    C = Array{AbstractTensor{Float64},1}(undef,length(materials))
+    E = Array{AbstractTensor{Float64},1}(undef,length(materials))
+
+    @info "using TensorMatrixType = $TensorMatrixType"
+    for m = 1 : length(materials)
+
+        ## get material data set
+        data[m] = MaterialParameters(materials[m], MST)
+
+        ## setup tensors
+        if MST <: ZincBlende001
+            C11 = data[m].ElasticConstants["C11"]
+            C12 = data[m].ElasticConstants["C12"]
+            C44 = data[m].ElasticConstants["C44"]
+
+            # stiffness tensor in N/(nm)^2 # todo: move scaling to solver
+            # Equation (4)
+            # in "Symmetry-adapted calculations of strain and polarization fields in (111)-oriented zinc-blende quantum dots" by Schulz et. al
+            C[m] = TensorMatrixType(
+              1e-9*[ C11 C12 C12   0   0   0
+                     C12 C11 C12   0   0   0
+                     C12 C12 C11   0   0   0
+                       0   0   0 C44   0   0
+                       0   0   0   0 C44   0
+                       0   0   0   0   0 C44 ])
+
+            # piezoelectric tensor in C/(nm^2)
+            # Equation (22)
+            E14zb = data[m].PiezoElectricConstants["E14zb"]
+            E[m] = TensorMatrixType(
+                  1e-9*[0 0 0 E14zb     0     0
+                   0 0 0     0 E14zb     0
+                   0 0 0     0     0 E14zb])
+        elseif MST <: ZincBlende2D
+            C11 = data[m].ElasticConstants["C11"]
+            C12 = data[m].ElasticConstants["C12"]
+            C44 = data[m].ElasticConstants["C44"]
+
+            # stiffness tensor in N/(nm)^2
+            C[m] = TensorMatrixType(
+                   1e-9*[ C11 C12   0
+                          C12 C11   0
+                            0   0 C44 ])
+
+            # piezoelectric tensor in C/(nm^2)
+            E14zb = data[m].PiezoElectricConstants["E14zb"]
+            E[m] = TensorMatrixType(
+                1e-9*[E14zb     0 0 0 0 0
+                     0 E14zb 0 0 0 0])
+        elseif MST <: ZincBlende111_C14 || MST <: ZincBlende111_C15 || MST <: ZincBlende111_C14_C15
+            C11 = data[m].ElasticConstants["C11"]
+            C12 = data[m].ElasticConstants["C12"]
+            C44 = data[m].ElasticConstants["C44"]
+            sr2 = sqrt(2)
+            C11p = (1/2)*(C11 + C12) + C44
+            C12p = (1/6)*(C11 + 5*C12) - (1/3)*C44
+            C44p = (1/3)*(C11 - C12 + C44)
+            C33p = (3/2)*C11p - (1/2)*C12p - C44p
+            C13p = -(1/2)*C11p + (3/2)*C12p + C44p
+            C14p = sr2/6*(-C11 + C12 + 2*C44)
+            C15p = (1/sr2)*C11p - (1/sr2)*C12p - sr2*C44p
+            C66p = (1/2)*(C11p - C12p)
+
+            # stiffness tensor in N/(nm)^2
+            # Equation (14)
+            if MST <: ZincBlende111_C14
+                C[m] = TensorMatrixType(
+                    1e-9*[  C11p    C12p    C13p    C14p    0       0
+                            C12p    C11p    C13p    -C14p   0       0
+                            C13p    C13p    C33p    0       0       0
+                            C14p    -C14p   0       C44p    0       0
+                            0       0       0       0       C44p    C14p
+                            0       0       0       0       C14p    C66p])
+            elseif MST <: ZincBlende111_C15
+                C[m] = TensorMatrixType(
+                    1e-9*[  C11p    C12p    C13p    0       C15p    0
+                            C12p    C11p    C13p    0       -C15p   0
+                            C13p    C13p    C33p    0       0       0
+                            0       0       0       C44p    0       -C15p
+                            C15p    -C15p   0       0       C44p     0
+                            0       0       0       -C15p   0       C66p])
+            elseif MST <: ZincBlende111_C14_C15
+                C[m] = TensorMatrixType(
+                    1e-9*[  C11p    C12p    C13p    C14p    C15p    0
+                            C12p    C11p    C13p    -C14p   -C15p   0
+                            C13p    C13p    C33p    0       0       0
+                            C14p    -C14p   0       C44p    0       -C15p
+                            C15p    -C15p   0       0       C44p     C14p
+                            0       0       0       -C15p   C14p    C66p])
+            end
+
+            # piezoelectric tensor in C/(nm^2)
+            # Equation (27)
+            E14zb = data[m].PiezoElectricConstants["E14zb"]
+            E11 = - sqrt(2/3) * E14zb
+            E12 = sqrt(2/3) * E14zb
+            E15 = - sqrt(1/3) * E14zb
+            E31 = E15
+            E33 = 2/sqrt(3) * E14zb
+
+            E[m] = TensorMatrixType(
+                   1e-9*[E11 E12 0   0   E15 0
+                    0   0   0   E15 0   E12
+                    E31 E31 E33 0   0   0])
+        elseif MST <: Wurtzite0001
+            C11 = data[m].ElasticConstants["C11"]
+            C12 = data[m].ElasticConstants["C12"]
+            C44 = data[m].ElasticConstants["C44"]
+            C11wz = (1/6) * (3*C11 + 3 * C12 + 6 * C44)
+            C33wz = (1/6) * (2*C11 + 4 * C12 + 8 * C44)
+            C12wz = (1/6) * (1*C11 + 5 * C12 - 2 * C44)
+            C13wz = (1/6) * (2*C11 + 4 * C12 - 4 * C44)
+            C44wz = (1/6) * (2*C11 - 2 * C12 + 2 * C44)
+            C66wz = (1/6) * (1*C11 - 1 * C12 + 4 * C44)
+
+            # stiffness tensor in N/(nm)^2
+            # Equation (7)
+            C[m] = TensorMatrixType(
+                   1e-9*[ C11wz C12wz C13wz 0     0     0
+                          C12wz C11wz C13wz 0     0     0
+                          C13wz C13wz C33wz 0     0     0
+                          0     0     0     C44wz 0     0
+                          0     0     0     0     C44wz 0
+                          0     0     0     0     0     C66wz ])
+
+            # piezoelectric tensor in C/(nm^2)
+            # Equation (25)
+            E31wz = data[m].PiezoElectricConstants["E31wz"]
+            E33wz = data[m].PiezoElectricConstants["E33wz"]
+            E15wz = data[m].PiezoElectricConstants["E15wz"]
+            E[m] = TensorMatrixType(
+                   1e-9*[     0     0     0     0  E15wz  0 
+                         0     0     0 E15wz      0  0 
+                     E31wz E31wz E33wz     0      0  0 ])
+        end
+    end
+
+    return HeteroStructureData{Float64,MST}(data,C,E)
+end

--- a/src/materials.jl
+++ b/src/materials.jl
@@ -41,7 +41,7 @@ Base.String(T::Type{<:InGaAs}) = "In_$(T.parameters[1])Ga_$(1 - T.parameters[1])
 Data set that collects all parameters for a material (region), i.e.
 elastic constants, piezoelextric constants, lattice constants, the spontaneous polarization constant and the relative dielectric constant.
 """
-struct MaterialDataset{T, MT <: MaterialType, MST <: MaterialStructureType}
+struct MaterialParameters{T, MT <: MaterialType, MST <: MaterialStructureType}
     """
     Elastic Constants
     """
@@ -65,46 +65,23 @@ struct MaterialDataset{T, MT <: MaterialType, MST <: MaterialStructureType}
 end
 
 
-
-"""
-````
-function IsotropicElasticityTensor(MD::MaterialDataset)
-````
-
-Construct an isotropic elasticity tensor from the given MaterialDataSet.
-
-"""
-function IsotropicElasticityTensor(MD::MaterialDataset{T, MT, MST}) where {T,MT,MST}
-    # compute Lamé constants in N/(m)^2
-    if haskey(d, "λ") && haskey(d, "μ")
-        λ = MD("λ")
-        μ = MD("μ")
-    elseif haskey(d, "C11") && haskey(d, "C44")
-        λ = MD("C11") - 2*MD("C44")
-        μ = MD("C44")
-    else
-        @error "material data does not contain enough values to init isotropic elasticity tensor (needs λ, μ or C11, C44)"
-    end
-    return IsotropicElasticityTensor{3,T}(λ, μ)
-end
-
-function get_kappar(mds::MaterialDataset)
+function get_kappar(mds::MaterialParameters)
     MT=get_materialtype(mds)
     return MT(mds.kappar)
 end
 
-get_materialtype(::MaterialDataset{T,MT,MST}) where {T,MT,MST} = MT
+get_materialtype(::MaterialParameters{T,MT,MST}) where {T,MT,MST} = MT
 
 
 """
 ````
-function MaterialDataset(MT::MaterialType)
+function MaterialParameters(MT::MaterialType)
 ````
 
 Returns the MaterialDateset for MaterialType MT.
 
 """
-function MaterialDataset(MT::Type{TestMaterial{x}}) where {x}
+function MaterialParameters(MT::Type{TestMaterial{x}}) where {x}
     # elastic constants
     ElasticConstants = Dict()
     ElasticConstants["C11"] = 1200 # GPa
@@ -126,10 +103,10 @@ function MaterialDataset(MT::Type{TestMaterial{x}}) where {x}
     # relative dielectric constant 
     kappar = 10.0
 
-    return MaterialDataset{Float64, MT}(ElasticConstants, PiezoElectricConstants, lc, Psp, kappar)
+    return MaterialParameters{Float64, MT}(ElasticConstants, PiezoElectricConstants, lc, Psp, kappar)
 end
 
-function MaterialDataset(MT::Type{GaAs}, MST::Type{<:MaterialStructureType})
+function MaterialParameters(MT::Type{GaAs}, MST::Type{<:MaterialStructureType})
 
     # elastic constants
     # Phys. Rev. B 95, 245309 (2017)
@@ -164,10 +141,10 @@ function MaterialDataset(MT::Type{GaAs}, MST::Type{<:MaterialStructureType})
     # relative dielectric constant
     kappar = 12.9 # http://www.ioffe.ru/SVA/NSM/Semicond/GaAs/basic.html
 
-    return MaterialDataset{Float64, MT, MST}(ElasticConstants, PiezoElectricConstants, lc, Psp, kappar)
+    return MaterialParameters{Float64, MT, MST}(ElasticConstants, PiezoElectricConstants, lc, Psp, kappar)
 end
 
-function MaterialDataset(MT::Type{AlInAs{x}}, MST::Type{<:MaterialStructureType}) where {x}
+function MaterialParameters(MT::Type{AlInAs{x}}, MST::Type{<:MaterialStructureType}) where {x}
     # elastic constants
     ElasticConstants = Dict() # from Vurgaftman, see also SPHInX AlInAs.sx file
     ElasticConstants["C11"] = x*125.0 + (1-x)*83.29 # GPa
@@ -198,10 +175,10 @@ function MaterialDataset(MT::Type{AlInAs{x}}, MST::Type{<:MaterialStructureType}
     # relative dielectric constant
     kappar = x*10.06  + (1-x)*15.15 # from https://www.ioffe.ru/SVA/NSM/Semicond/AlGaAs/basic.html and https://www.ioffe.ru/SVA/NSM/Semicond/InAs/basic.html
 
-    return MaterialDataset{Float64, MT, MST}(ElasticConstants, PiezoElectricConstants, lc, Psp, kappar)
+    return MaterialParameters{Float64, MT, MST}(ElasticConstants, PiezoElectricConstants, lc, Psp, kappar)
 end
 
-function MaterialDataset(MT::Type{AlGaAs{x}}, MST::Type{<:MaterialStructureType}) where {x}
+function MaterialParameters(MT::Type{AlGaAs{x}}, MST::Type{<:MaterialStructureType}) where {x}
     # elastic constants (taken from GaAs / AlAs data above)
     ElasticConstants = Dict()
     ElasticConstants["C11"] = x*125.0 + (1-x)*122.1 # GPa
@@ -230,10 +207,10 @@ function MaterialDataset(MT::Type{AlGaAs{x}}, MST::Type{<:MaterialStructureType}
     # relative dielectric constant (taken from GaAs / AlAs data above)
     kappar = x*10.06  + (1-x)*12.9
 
-    return MaterialDataset{Float64, MT, MST}(ElasticConstants, PiezoElectricConstants, lc, Psp, kappar)
+    return MaterialParameters{Float64, MT, MST}(ElasticConstants, PiezoElectricConstants, lc, Psp, kappar)
 end
 
-function MaterialDataset(MT::Type{InGaAs{x}}, MST::Type{<:MaterialStructureType}) where {x}
+function MaterialParameters(MT::Type{InGaAs{x}}, MST::Type{<:MaterialStructureType}) where {x}
     # elastic constants (taken from InAs / GaAs data above)
     ElasticConstants = Dict()
     ElasticConstants["C11"] = x*83.29 + (1-x)*122.1 # GPa
@@ -262,160 +239,6 @@ function MaterialDataset(MT::Type{InGaAs{x}}, MST::Type{<:MaterialStructureType}
     # relative dielectric constant (taken from InAs / GaAs data above)
     kappar = x*15.15  + (1-x)*12.9
 
-    return MaterialDataset{Float64, MT, MST}(ElasticConstants, PiezoElectricConstants, lc, Psp, kappar)
+    return MaterialParameters{Float64, MT, MST}(ElasticConstants, PiezoElectricConstants, lc, Psp, kappar)
 end
 
-
-"""
-    $(TYPEDEF)
-
-structure that collects material data sets, elasticity tensors and piezoelectric tensors for all materials
-"""
-struct MaterialData{T, MST <: MaterialStructureType}
-    data::Array{MaterialDataset,1}
-    TensorC::Array{<:ElasticityTensorType{T},1}         # elastitity tensor C
-    TensorE::Array{<:PiezoElectricityTensorType{T},1}   # piezo-electricity tensor E
-end
-
-### coefficients ###
-function set_data(materials::Array{DataType,1}, MST::Type{<:MaterialStructureType})
-
-    data = Array{MaterialDataset,1}(undef, length(materials))
-    C = Array{CustomMatrixElasticityTensor{Float64},1}(undef,length(materials))
-    E = Array{CustomMatrixPiezoElectricityTensor{Float64},1}(undef,length(materials))
-
-    for m = 1 : length(materials)
-
-        ## get material data set
-        data[m] = MaterialDataset(materials[m], MST)
-
-        ## setup tensors
-        if MST <: ZincBlende001
-            C11 = data[m].ElasticConstants["C11"]
-            C12 = data[m].ElasticConstants["C12"]
-            C44 = data[m].ElasticConstants["C44"]
-
-            # stiffness tensor in N/(nm)^2 # todo: move scaling to solver
-            # Equation (4)
-            # in "Symmetry-adapted calculations of strain and polarization fields in (111)-oriented zinc-blende quantum dots" by Schulz et. al
-            C[m] = CustomMatrixElasticityTensor(
-              1e-9*[ C11 C12 C12   0   0   0
-                     C12 C11 C12   0   0   0
-                     C12 C12 C11   0   0   0
-                       0   0   0 C44   0   0
-                       0   0   0   0 C44   0
-                       0   0   0   0   0 C44 ])
-
-            # piezoelectric tensor in C/(nm^2)
-            # Equation (22)
-            E14zb = data[m].PiezoElectricConstants["E14zb"]
-            E[m] = CustomMatrixPiezoElectricityTensor(
-                  1e-9*[0 0 0 E14zb     0     0
-                   0 0 0     0 E14zb     0
-                   0 0 0     0     0 E14zb])
-        elseif MST <: ZincBlende2D
-            C11 = data[m].ElasticConstants["C11"]
-            C12 = data[m].ElasticConstants["C12"]
-            C44 = data[m].ElasticConstants["C44"]
-
-            # stiffness tensor in N/(nm)^2
-            C[m] = CustomMatrixElasticityTensor(
-                   1e-9*[ C11 C12   0
-                          C12 C11   0
-                            0   0 C44 ])
-
-            # piezoelectric tensor in C/(nm^2)
-            E14zb = data[m].PiezoElectricConstants["E14zb"]
-            E[m] = CustomMatrixPiezoElectricityTensor(
-                1e-9*[E14zb     0 0 0 0 0
-                     0 E14zb 0 0 0 0])
-        elseif MST <: ZincBlende111_C14 || MST <: ZincBlende111_C15 || MST <: ZincBlende111_C14_C15
-            C11 = data[m].ElasticConstants["C11"]
-            C12 = data[m].ElasticConstants["C12"]
-            C44 = data[m].ElasticConstants["C44"]
-            sr2 = sqrt(2)
-            C11p = (1/2)*(C11 + C12) + C44
-            C12p = (1/6)*(C11 + 5*C12) - (1/3)*C44
-            C44p = (1/3)*(C11 - C12 + C44)
-            C33p = (3/2)*C11p - (1/2)*C12p - C44p
-            C13p = -(1/2)*C11p + (3/2)*C12p + C44p
-            C14p = sr2/6*(-C11 + C12 + 2*C44)
-            C15p = (1/sr2)*C11p - (1/sr2)*C12p - sr2*C44p
-            C66p = (1/2)*(C11p - C12p)
-
-            # stiffness tensor in N/(nm)^2
-            # Equation (14)
-            if MST <: ZincBlende111_C14
-                C[m] = CustomMatrixElasticityTensor(
-                    1e-9*[  C11p    C12p    C13p    C14p    0       0
-                            C12p    C11p    C13p    -C14p   0       0
-                            C13p    C13p    C33p    0       0       0
-                            C14p    -C14p   0       C44p    0       0
-                            0       0       0       0       C44p    C14p
-                            0       0       0       0       C14p    C66p])
-            elseif MST <: ZincBlende111_C15
-                C[m] = CustomMatrixElasticityTensor(
-                    1e-9*[  C11p    C12p    C13p    0       C15p    0
-                            C12p    C11p    C13p    0       -C15p   0
-                            C13p    C13p    C33p    0       0       0
-                            0       0       0       C44p    0       -C15p
-                            C15p    -C15p   0       0       C44p     0
-                            0       0       0       -C15p   0       C66p])
-            elseif MST <: ZincBlende111_C14_C15
-                C[m] = CustomMatrixElasticityTensor(
-                    1e-9*[  C11p    C12p    C13p    C14p    C15p    0
-                            C12p    C11p    C13p    -C14p   -C15p   0
-                            C13p    C13p    C33p    0       0       0
-                            C14p    -C14p   0       C44p    0       -C15p
-                            C15p    -C15p   0       0       C44p     C14p
-                            0       0       0       -C15p   C14p    C66p])
-            end
-
-            # piezoelectric tensor in C/(nm^2)
-            # Equation (27)
-            E14zb = data[m].PiezoElectricConstants["E14zb"]
-            E11 = - sqrt(2/3) * E14zb
-            E12 = sqrt(2/3) * E14zb
-            E15 = - sqrt(1/3) * E14zb
-            E31 = E15
-            E33 = 2/sqrt(3) * E14zb
-
-            E[m] = CustomMatrixPiezoElectricityTensor(
-                   1e-9*[E11 E12 0   0   E15 0
-                    0   0   0   E15 0   E12
-                    E31 E31 E33 0   0   0])
-        elseif MST <: Wurtzite0001
-            C11 = data[m].ElasticConstants["C11"]
-            C12 = data[m].ElasticConstants["C12"]
-            C44 = data[m].ElasticConstants["C44"]
-            C11wz = (1/6) * (3*C11 + 3 * C12 + 6 * C44)
-            C33wz = (1/6) * (2*C11 + 4 * C12 + 8 * C44)
-            C12wz = (1/6) * (1*C11 + 5 * C12 - 2 * C44)
-            C13wz = (1/6) * (2*C11 + 4 * C12 - 4 * C44)
-            C44wz = (1/6) * (2*C11 - 2 * C12 + 2 * C44)
-            C66wz = (1/6) * (1*C11 - 1 * C12 + 4 * C44)
-
-            # stiffness tensor in N/(nm)^2
-            # Equation (7)
-            C[m] = CustomMatrixElasticityTensor(
-                   1e-9*[ C11wz C12wz C13wz 0     0     0
-                          C12wz C11wz C13wz 0     0     0
-                          C13wz C13wz C33wz 0     0     0
-                          0     0     0     C44wz 0     0
-                          0     0     0     0     C44wz 0
-                          0     0     0     0     0     C66wz ])
-
-            # piezoelectric tensor in C/(nm^2)
-            # Equation (25)
-            E31wz = data[m].PiezoElectricConstants["E31wz"]
-            E33wz = data[m].PiezoElectricConstants["E33wz"]
-            E15wz = data[m].PiezoElectricConstants["E15wz"]
-            E[m] = CustomMatrixPiezoElectricityTensor(
-                   1e-9*[     0     0     0     0  E15wz  0 
-                         0     0     0 E15wz      0  0 
-                     E31wz E31wz E33wz     0      0  0 ])
-        end
-    end
-
-    return MaterialData{Float64,MST}(data,C,E)
-end

--- a/src/solvers_from_energy.jl
+++ b/src/solvers_from_energy.jl
@@ -41,14 +41,14 @@ function ∂FW!(M, invM, detM, STT, PET = nothing, kappar = nothing)
         compute_strain!(_ϵ, _F)
 
         # apply elasticity tensor Cϵ = C : ϵ
-        apply_elasticity_tensor!(_Cϵ, _ϵ, STT[region])
+        apply_tensor!(_Cϵ, _ϵ, STT[region])
 
         # compute energy
         result[1] = dot(_Cϵ, _ϵ) / 2
 
         if polarisation
             ## apply piezo-eletricity tensor Eϵ = E : ϵ
-            apply_piezoelectricity_tensor!(_Eϵ, _ϵ, PET[region])
+            apply_tensor!(_Eϵ, _ϵ, PET[region])
 
             ## add to energy
             result[1] -= dot(_Eϵ, _E)

--- a/src/tensors.jl
+++ b/src/tensors.jl
@@ -1,84 +1,94 @@
 """
 $(TYPEDEF)
 """
-abstract type ElasticityTensorType{T} end
+abstract type AbstractTensor{T} end
 
 """
     $(TYPEDEF)
 
 Isotropic elasticity tensor with two Lame parameters λ and μ.
 """
-struct IsotropicElasticityTensor{dim,T} <: ElasticityTensorType{T} 
+struct IsotropicElasticityTensor{dim,T} <: AbstractTensor{T} 
     λ::T
     μ::T
     IsotropicElasticityTensor(λ,μ,dim) = new{dim, Float64}(λ,μ)
 end
 
+"""
+````
+function IsotropicElasticityTensor(MD::MaterialParameters)
+````
+
+Construct an isotropic elasticity tensor from the given MaterialParameters.
+
+"""
+function IsotropicElasticityTensor(MD::MaterialParameters{T, MT, MST}) where {T,MT,MST}
+    # compute Lamé constants in N/(m)^2
+    if haskey(d, "λ") && haskey(d, "μ")
+        λ = MD("λ")
+        μ = MD("μ")
+    elseif haskey(d, "C11") && haskey(d, "C44")
+        λ = MD("C11") - 2*MD("C44")
+        μ = MD("C44")
+    else
+        @error "material data does not contain enough values to init isotropic elasticity tensor (needs λ, μ or C11, C44)"
+    end
+    return IsotropicElasticityTensor{3,T}(λ, μ)
+end
+
 
 """
     $(TYPEDEF)
 
-Custom elasticity tensor that takes any matrix (e.g. 3x3 in 2D and 6x6 in 3D),
-that encodes the mapping of the strain (in Voigt notation) to the stress tensor (in Voigt notation)
+Custom tensor with sparse matrix representation
 """
-struct CustomMatrixElasticityTensor{T} <: ElasticityTensorType{T}
+struct SparseMatrixTensor{T} <: AbstractTensor{T}
+    C::SparseMatrixCSC{T,Int}
+end
+
+function SparseMatrixTensor(M::AbstractMatrix{T}) where {T}
+    return SparseMatrixTensor{T}(SparseMatrixCSC{T,Int}(M))
+end
+
+
+"""
+    $(TYPEDEF)
+
+Custom tensor with dense matrix representation
+"""
+struct DenseMatrixTensor{T} <: AbstractTensor{T}
     C::Matrix{T}
 end
+
 # TODO: Wurtzite/ZincBlende etc. could be cast into a constructor for CustomMatrixTensor
 #       or we could even make subtypes with apply functions for them to skip the zeros in their evaluation
 
 
-@inline function apply_elasticity_tensor!(result, input, ST::IsotropicElasticityTensor{2,T}; offset = 0) where {T}
-    result[offset + 1] = ST.λ * (input[1] + input[2]) + 2 * ST.μ * input[1]
-    result[offset + 2] = ST.λ * (input[1] + input[2]) + 2 * ST.μ * input[2]
-    result[offset + 3] = 2 * ST.μ * input[3]
+@inline function apply_tensor!(result, input, ST::IsotropicElasticityTensor{2,T}, offset = 0, input_offset = 0) where {T}
+    result[offset + 1] = ST.λ * (input[input_offset + 1] + input[input_offset + 2]) + 2 * ST.μ * input[input_offset + 1]
+    result[offset + 2] = ST.λ * (input[input_offset + 1] + input[input_offset + 2]) + 2 * ST.μ * input[input_offset + 2]
+    result[offset + 3] = 2 * ST.μ * input[input_offset + 3]
     return nothing 
 end
 
-@inline function apply_elasticity_tensor!(result, input, ST::IsotropicElasticityTensor{3,T}; offset = 0) where {T}
-    result[offset + 1] = ST.λ * (input[1] + input[2] + input[3]) + 2 * ST.μ * input[1]
-    result[offset + 2] = ST.λ * (input[1] + input[2] + input[3]) + 2 * ST.μ * input[2]
-    result[offset + 3] = ST.λ * (input[1] + input[2] + input[3]) + 2 * ST.μ * input[3]
-    result[offset + 4] = 2 * ST.μ * input[4]
-    result[offset + 5] = 2 * ST.μ * input[5]
-    result[offset + 6] = 2 * ST.μ * input[6]
+@inline function apply_tensor!(result, input, ST::IsotropicElasticityTensor{3,T}, offset = 0, input_offset = 0) where {T}
+    result[offset + 1] = ST.λ * (input[input_offset + 1] + input[input_offset + 2] + input[input_offset + 3]) + 2 * ST.μ * input[input_offset + 1]
+    result[offset + 2] = ST.λ * (input[input_offset + 1] + input[input_offset + 2] + input[input_offset + 3]) + 2 * ST.μ * input[input_offset + 2]
+    result[offset + 3] = ST.λ * (input[input_offset + 1] + input[input_offset + 2] + input[input_offset + 3]) + 2 * ST.μ * input[input_offset + 3]
+    result[offset + 4] = 2 * ST.μ * input[input_offset + 4]
+    result[offset + 5] = 2 * ST.μ * input[input_offset + 5]
+    result[offset + 6] = 2 * ST.μ * input[input_offset + 6]
     return nothing 
 end
 
-@inline function apply_elasticity_tensor!(result, input, ST::CustomMatrixElasticityTensor{T}; offset = 0) where {T}
-    C::Matrix{T} = ST.C
-    for k = 1 : size(C,1)
-        result[offset + k] = 0
-        for j = 1 : size(C,2)
-            if C[k,j] != 0
-                result[offset + k] += C[k,j] * input[j]
-            end
-        end
-    end
+@inline function apply_tensor!(result, input, ST::SparseMatrixTensor{T}, offset = 0, input_offset = 0) where {T}
+    C = ST.C
+    mul!(view(result,offset+1:offset+size(C,1)), C, view(input, input_offset+1:input_offset+size(C,2)))
     return nothing 
 end
 
-
-
-"""
-    $(TYPEDEF)
-
-"""
-abstract type PiezoElectricityTensorType{T} end
-
-"""
-    $(TYPEDEF)
-
-Custom piezo-elecitrcity tensor that takes any matrix (e.g. 3x2 in 2D and 6x3 in 3D),
-that encodes the mapping of the stress (in Voigt notation) to the polarization.
-"""
-struct CustomMatrixPiezoElectricityTensor{T} <: PiezoElectricityTensorType{T}
-    C::Matrix{T}
-end
-# Wurtzite/ZincBlende etc. could be cast into a constructor for CustomMatrixTensor
-
-@inline function apply_piezoelectricity_tensor!(result, input, PET::CustomMatrixPiezoElectricityTensor{T}; offset = 0, input_offset = 0) where {T}
-    C::Matrix{T} = PET.C
+@inline function apply_tensor!(result, input, ST::DenseMatrixTensor{T}, offset = 0, input_offset = 0) where {T}
+    C = ST.C
     for k = 1 : size(C,1)
         result[offset + k] = 0
         for j = 1 : size(C,2)


### PR DESCRIPTION
- renamed project from NanoWiresJulia to StrainedBandstructures,
- renamed MaterialDataset to MaterialParameters
- renamed MaterialData to HeteroStructureData (now in its own file) and set_data to HeteroStructureData (constructor)
- no seperate tensor supertypes for elasticity and piezoeletricity, all tensors implement apply_tensor!
- SparseMatrixTensor and DenseMatrixTensor replace the Custom***Tensors, unfortunately I did not see any advantage by using SparseMatrixTensor
- adjusted documentation